### PR TITLE
Update build and deploy workflow for hard links

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -42,18 +42,14 @@ jobs:
                   cd aswin-home
                   npm install
                   npm run build
-                  
-            - name: Check for hard links
-              run: |
-                cd aswin-home/out
-                find . -type f -links +1
 
-            - name: Remove symlinks and problematic files
+            - name: Break hard links with tar
               run: |
-                  cd aswin-home/out
-                  find . -type l -delete
-                  find . -type d -name '.next' -exec rm -rf {} + 2>/dev/null || true
-                  find . -name '.DS_Store' -delete
+                  cd aswin-home
+                  tar -czf /tmp/out.tar.gz out/
+                  rm -rf out
+                  tar -xzf /tmp/out.tar.gz
+                  rm /tmp/out.tar.gz
 
             - name: Setup Pages
               uses: actions/configure-pages@v4


### PR DESCRIPTION
Modified the build and deploy workflow to break hard links using tar instead of checking for them and removing problematic files.